### PR TITLE
Adding capability to choose units for muscle weight entry

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v3"
+      - uses: home-assistant/actions/hassfest@master

--- a/custom_components/garmin_scale_sync/button.py
+++ b/custom_components/garmin_scale_sync/button.py
@@ -38,7 +38,7 @@ class SendValuesButton(ButtonEntity):
     ) -> None:
         """Initialize the button."""
         self._attr_unique_id = f"{base_unique_id}_{entity_suffix}"
-        self._attr_name = "Send Values"
+        self._attr_name = entity_suffix
         self._attr_icon = "mdi:send"
         self.hass = hassHandler
         self.entryID = base_unique_id

--- a/custom_components/garmin_scale_sync/const.py
+++ b/custom_components/garmin_scale_sync/const.py
@@ -4,13 +4,23 @@ DOMAIN = "garmin_scale_sync"
 
 
 # defining entities suffixes
-SUFFIX_WEIGHT = "body_weight"
-SUFFIX_BODYFAT = "body_fat"
-SUFFIX_MUSCLEWEIGHT = "muscle_weight"
-SUFFIX_VICERALFAT = "viceralfat"
-SUFFIX_MEASUREMENT_DATETIME = "measurementDateTime"
-SUFFIX_BTN_SEND_DATA = "btnSendtoConnect"
+SUFFIX_WEIGHT = "gsc_body_weight"
+SUFFIX_BODYFAT = "gsc_body_fat"
+SUFFIX_MUSCLEWEIGHT = "gsc_muscle_weight"
+SUFFIX_VICERALFAT = "gsc_viceralfat"
+SUFFIX_MEASUREMENT_DATETIME = "gsc_measurementDateTime"
+SUFFIX_BTN_SEND_DATA = "gsc_btnSendtoConnect"
 
 # defining Config Keys
-GSC_MUSCLEDATA_IN_PERCENT = "muscleDataInPercent"
+GSC_MUSCLEDATA_UNITS = "muscleDataDefinedUnit"
 GSC_OAUTH_TOKEN = "oauthToken"
+GSC_BODY_HEIGHT = "bodyheight"
+
+# defining some enums
+GARTH_LOGIN_SUCCESS = 1
+GARTH_LOGIN_FAILED = 0
+
+
+# defining keys for the user in which unit they wil type in the
+# musclemass
+MUSCLEMASS_INPUT_UNIT = ["kg", "%"]

--- a/custom_components/garmin_scale_sync/datetime.py
+++ b/custom_components/garmin_scale_sync/datetime.py
@@ -31,7 +31,7 @@ class GarminDateTimeInput(DateTimeEntity):
     """Entity for date input."""
 
     def __init__(self, base_unique_id: str, entity_suffix: str) -> None:
-        self._attr_name = "Garmin Date Input"
+        self._attr_name = entity_suffix
         self._attr_icon = "mdi:calendar"
         self._attr_unique_id = f"{base_unique_id}_{entity_suffix}"
         self._attr_has_date = True

--- a/custom_components/garmin_scale_sync/number.py
+++ b/custom_components/garmin_scale_sync/number.py
@@ -51,7 +51,7 @@ class GarminScaleBaseEntity(NumberEntity):
         unit_of_measurement: str,
     ) -> None:
         super().__init__()
-        self._attr_name = name
+        self._attr_name = entity_suffix
         self._attr_unique_id = f"{base_unique_id}_{entity_suffix}"
         self._attr_mode = NumberMode.BOX
         self._attr_native_max_value = max_value

--- a/custom_components/garmin_scale_sync/strings.json
+++ b/custom_components/garmin_scale_sync/strings.json
@@ -2,12 +2,12 @@
   "config": {
     "step": {
       "user": {
-        "name":"Fill data",
         "data": {
           "alias": "Alias",
           "username": "Username",
           "password": "Password",
-          "optimistic": "Musclemass data is in percent"
+          "bodyheight": "Bodyheight in centimeters, used for calculation of the BMI",
+          "muscleDataDefinedUnit": "In which unit will you enter your muscle weight?"
         },
         "description": "Configure a Device for Garmin Connect.\n Please enter your Credentials."
       }
@@ -20,10 +20,10 @@
           "alias": "Alias",
           "username": "Username",
           "password": "Password",
-          "optimistic": "Musclemass data is in percent"
+          "bodyheight": "Bodyheight in centimeters, used for calculation of the BMI",
+          "muscleDataDefinedUnit": "In which unit will you enter your muscle weight?"
         },
-        "description": "Fill Data",
-        "name": "title"
+        "description": "Configure a Device for Garmin Connect.\n Please enter your Credentials."
       }
     }
   }

--- a/custom_components/garmin_scale_sync/translations/de.json
+++ b/custom_components/garmin_scale_sync/translations/de.json
@@ -1,30 +1,30 @@
 {
     "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "alias": "Alias",
-                    "optimistic": "Muskeldaten werden in Prozent angegeben?",
-                    "password": "Passwort",
-                    "username": "Benutzernamen"
-                },
-                "description": "Erstellen eines Gerätes für Garmin Connect.\n Bitte Zugangsdaten eingeben.",
-                "name": "Fill data"
-            }
+      "step": {
+        "user": {
+          "data": {
+            "alias": "Alias",
+            "username": "Benutzername",
+            "password": "Passwort",
+            "bodyheight": "Körpergröße in Zentimetern, die für die Berechnung des BMI verwendet wird",
+            "muscleDataDefinedUnit": "In welcher Einheit wirst du das Muskelgewicht eingeben?"
+          },
+          "description": "Konfiguriere ein Gerät für Garmin Connect.\n Bitte gebe deine Anmeldeinformationen ein."
         }
+      }
     },
     "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "alias": "Alias",
-                    "optimistic": "Musclemass data is in percent",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Fill Data",
-                "name": "title"
+      "step": {
+        "init": {
+            "data": {
+                "alias": "Alias",
+                "username": "Benutzername",
+                "password": "Passwort",
+                "bodyheight": "Körpergröße in Zentimetern, die für die Berechnung des BMI verwendet wird",
+                "muscleDataDefinedUnit": "In welcher Einheit wirst du das Muskelgewicht eingeben?"
+              },
+              "description": "Konfiguriere ein Gerät für Garmin Connect.\n Bitte gebe deine Anmeldeinformationen ein."
             }
-        }
+      }
     }
-}
+  }

--- a/custom_components/garmin_scale_sync/translations/en.json
+++ b/custom_components/garmin_scale_sync/translations/en.json
@@ -1,30 +1,30 @@
 {
-    "config": {
-        "step": {
-            "user": {
-                "data": {
-                    "alias": "Alias",
-                    "optimistic": "Musclemass data is in percent",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Configure a Device for Garmin Connect.\n Please enter your Credentials.",
-                "name": "Fill data"
-            }
-        }
-    },
-    "options": {
-        "step": {
-            "init": {
-                "data": {
-                    "alias": "Alias",
-                    "optimistic": "Musclemass data is in percent",
-                    "password": "Password",
-                    "username": "Username"
-                },
-                "description": "Fill Data",
-                "name": "title"
-            }
-        }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "alias": "Alias",
+          "username": "Username",
+          "password": "Password",
+          "bodyheight": "Bodyheight in centimeters, used for calculation of the BMI",
+          "muscleDataDefinedUnit": "In which unit will you enter your muscle weight?"
+        },
+        "description": "Configure a Device for Garmin Connect.\n Please enter your Credentials."
+      }
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "alias": "Alias",
+          "username": "Username",
+          "password": "Password",
+          "bodyheight": "Bodyheight in centimeters, used for calculation of the BMI",
+          "muscleDataDefinedUnit": "In which unit will you enter your muscle weight?"
+        },
+        "description": "Configure a Device for Garmin Connect.\n Please enter your Credentials."
+      }
+    }
+  }
 }


### PR DESCRIPTION
In this pull request, I've introduced functionality to accommodate the way some body analysis scales report muscle mass. While these scales often display muscle mass as a percentage, Garmin Connect requires this data in kilograms. To address this, the setup process now includes an option for users to specify the unit in which their data is measured. If the user selects the percentage option, the integration will automatically convert the muscle mass data from percentage to kilograms before syncing with Garmin Connect.

Additionally, I've implemented a feature to calculate and send BMI (Body Mass Index) data. However, this is still a work in progress as the `fit_tool` library currently does not support BMI values. I'm exploring solutions for this limitation and plan to enhance this functionality in future updates.